### PR TITLE
Remove dependency on seq command

### DIFF
--- a/hr
+++ b/hr
@@ -27,9 +27,13 @@ else
     space_character='='
 fi
 
-for i in $(seq 1 $(tput cols));
+line=''
+cols=$(tput cols)
+
+for (( i=1; i<cols; i++ ))
 do
-    echo -n "${space_character}";
+    line+="${space_character}"
 done
 
+echo -n "${line}"
 echo ""


### PR DESCRIPTION
seq is not available on BSD systems by default. Switched to C-style for loop. Also created line buffer so that multiple echos are not required.
