### PR TITLE
More portable, sourceable and less dependencies

### DIFF
--- a/hr
+++ b/hr
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # The MIT License (MIT)
 #
@@ -21,27 +21,27 @@
 # IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
+hr()
+{
+    local COLS=${COLUMNS:-80}
+    local LINE=
 
-function hr {
-    word="$1"
-    line=''
-    while [[ ${#line} -lt $columns ]]; do
-        line="$line$word"
+    while (( ${#LINE} < $COLS ))
+    do
+        LINE=$LINE$1
     done
-    echo "${line:0:$columns}"
+
+    echo ${LINE:0:$COLS}
 }
 
+hrs()
+{
+    local WORD
 
-columns="$(tput cols)"
-if [[ "$columns" -lt 0 ]] ; then
-    columns=80
-fi
-
-if [[ $# > 0 ]]; then
-    for word in "$@" ; do
-        hr "$word"
+    for WORD in ${@:-#}
+    do
+        hr $WORD
     done
-else
-    hr "#"
-fi
+}
 
+[ "$0" == "$BASH_SOURCE" ] && hrs $@


### PR DESCRIPTION
# !/usr/bin/env bash is more portable than #!/bin/bash.

Used bash built-in shell variable COLUMNS instead of tput.

Used default values (${VAR:-N}) instead of if-then statement.

Made the script sourceable so it can be used from other scripts.

Made variables local.

Changed environment variables to upper case. Every variable in a bash script is a environment variable which is "global" for all subsequent invocations; see:

foo()
{
    echo $FOOBAR
}

bar()
{
    local FOOBAR=7
    foo
}

To reflect that, a bash variable should be upper case. But YMMV, so it's up to you. Just wanted to explain why some people use upper case.

Moved the ability to process multiple arguments in its own function. This way the tasks are atomized and the environment is not polluted by WORD because it can be local.
