### PR TITLE
Multiple changes:

### DIFF
--- a/hr
+++ b/hr
@@ -22,29 +22,30 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 hr() {
-    local COLS=$(tput cols)
+    local COLS="$(tput cols)"
 
-    if [[ "$COLS" -lt 0 ]] ; then
-        COLS=80
+    if [[ "$COLS" -le 0 ]] ; then
+        COLS="${COLUMNS:-80}"
     fi
 
-    local WORD=$1
+    local WORD="$1"
     local LINE=''
-    while (( ${#LINE} < $COLS ))
+    while (( ${#LINE} < "$COLS" ))
     do
-        LINE=$LINE$WORD
+        LINE="$LINE$WORD"
     done
 
-    echo ${LINE:0:$COLS}
+    echo "${LINE:0:$COLS}"
 }
 
 hrs() {
     local WORD
 
-    for WORD in ${@:-#}
+    for WORD in "${@:-#}"
     do
-        hr $WORD
+        WORD="${WORD:-#}"
+        hr "$WORD"
     done
 }
 
-[ "$0" == "$BASH_SOURCE" ] && hrs $@
+[ "$0" == "$BASH_SOURCE" ] && hrs "$@"


### PR DESCRIPTION
Quote variable references to avoid wildcard expansion
Use `tput cols`, falling back to $COLUMNS if that fails, falling back to 80 if that fails
    (May still fail if $COLUMNS is set to a non-number)
Fix test for valid $COLS
Use "#" if an argument is an empty string (avoids an infinite loop)
