### PR TITLE
If terminal supports UTF-8, use em-dash as default

### DIFF
--- a/hr
+++ b/hr
@@ -22,8 +22,16 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 COLS="$(tput cols)"
+LOCALE="$(locale charmap)"
+
 if [[ "$COLS" -le 0 ]] ; then
     COLS="${COLUMNS:-80}"
+fi
+
+if [[ "$LOCALE" = 'UTF-8' ]] ; then
+    BASECHAR="$(echo -e "\u2014")"
+else
+    BASECHAR="#"
 fi
 
 hr() {
@@ -42,7 +50,7 @@ hr() {
 hrs() {
     local WORD
 
-    for WORD in "${@:-#}"
+    for WORD in "${@:-$BASECHAR}"
     do
         hr "$WORD"
     done


### PR DESCRIPTION
This allows for a solid line (more reminiscent of a real <hr />) given your terminal has UTF-8 support, if your LOCALE is set to *.ASCII, falls back to default #
