### PR TITLE
Use bash shell arthmetic, remove redundant parameter expansion syntax.

### DIFF
--- a/hr
+++ b/hr
@@ -22,7 +22,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 COLS="$(tput cols)"
-if [[ "$COLS" -le 0 ]] ; then
+if (( COLS <= 0 )) ; then
     COLS="${COLUMNS:-80}"
 fi
 
@@ -30,7 +30,7 @@ hr() {
     local WORD="$1"
     if [[ -n "$WORD" ]] ; then
         local LINE=''
-        while (( ${#LINE} < "$COLS" ))
+        while (( ${#LINE} < COLS ))
         do
             LINE="$LINE$WORD"
         done


### PR DESCRIPTION
Within shell arithmetic expressions the parameter expansion syntax can be dropped.
