### PR TITLE
Add another Haskell implementation of hr

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ choice, check them out:
 * https://github.com/euangoddard/hr.py (Python)
 * https://github.com/ivantsepp/hr (Ruby)
 * https://github.com/bit-shift/hr-hs (Haskell)
+* https://github.com/HalosGhost/hs/blob/master/HR.hs (Haskell; avoids both shelling out and depending on ncurses)
 * https://github.com/xuxiaodong/hr (Perl)
 * https://github.com/ajkerrigan/pshr (Powershell)
 * https://github.com/HalosGhost/.bin/blob/master/src/hr.c (C)


### PR DESCRIPTION
This implementation offers a few fancy benefits over the presently available one:

1. It avoids shelling out and avoids depending on ncurses (instead depending on another pure Haskell library)
2. It broadcasts itself as a module so that other Haskellers can use it directly instead of needing to shell out to the utility.