### PR TITLE
Add header to hr

### DIFF
--- a/hr
+++ b/hr
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+### hr ###
+# A horizontal ruler for your terminal
+# From https://github.com/LuRsT/hr
+
 # The MIT License (MIT)
 #
 # Copyright (c) 2014 Gil Gonçalves


### PR DESCRIPTION
I've found that I don't actually remember where half of the tools in my `~/bin` folder came from, and they don't have links at the top of the file, so I can never find them again online.

I've added a simple header to the top of hr that tells you what it is, and where it came from.