### PR TITLE
Change default manpage prefix location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # <hr /> for your terminal
 
 PREFIX=/usr/local
-MANPREFIX=/usr/local
+MANPREFIX=/usr/local/share
 
 install:
 	cp hr $(PREFIX)/bin/hr


### PR DESCRIPTION
Updated the default manpage prefix location from the Makefile for OS compatibility issues.