### PR TITLE
Fix grep repetition count exhaustion

### DIFF
--- a/hr
+++ b/hr
@@ -31,7 +31,7 @@ hr() {
         return
     fi
 
-    printf '%*s' "$COLS" ' ' | sed "s/ /$1/g" | grep -o "^.\{$COLS\}"
+    printf '%*s' "$COLS" ' ' | sed "s/ /$1/g" | cut -c1-"$COLS"
 }
 
 hrs() {


### PR DESCRIPTION
Fixes the grep repetition count issue discussed in #63 by replacing grep-based truncation with cut. This avoids regex repetition limits on systems where grep enforces a hard maximum. Credit to @senki for the original idea.

Closes: #63